### PR TITLE
Fix: audit and fix Arabic translations

### DIFF
--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -92,7 +92,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "1.0.9"
+    version: "1.0.11"
   flutter_lints:
     dependency: "direct dev"
     description:
@@ -139,34 +139,34 @@ packages:
     dependency: transitive
     description:
       name: intl
-      sha256: "3bc132a9dbce73a7e4a21a17d06e1878839ffbf975568bc875c60537824b0c4d"
+      sha256: d6f56758b7d3014a48af9701c085700aac781a92a87a62b1333b46d8879661cf
       url: "https://pub.dev"
     source: hosted
-    version: "0.18.1"
+    version: "0.19.0"
   leak_tracker:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: "78eb209deea09858f5269f5a5b02be4049535f568c07b275096836f01ea323fa"
+      sha256: "7f0df31977cb2c0b88585095d168e689669a2cc9b97c309665e3386f3e9d341a"
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.0"
+    version: "10.0.4"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
       name: leak_tracker_flutter_testing
-      sha256: b46c5e37c19120a8a01918cfaf293547f47269f7cb4b0058f21531c2465d6ef0
+      sha256: "06e98f569d004c1315b991ded39924b21af84cf14cc94791b8aea337d25b57f8"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.1"
+    version: "3.0.3"
   leak_tracker_testing:
     dependency: transitive
     description:
       name: leak_tracker_testing
-      sha256: a597f72a664dbd293f3bfc51f9ba69816f84dcd403cdac7066cb3f6003f3ab47
+      sha256: "6ba465d5d76e67ddf503e1161d1f4a6bc42306f9d66ca1e8f079a47290fb06d3"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.1"
+    version: "3.0.1"
   lints:
     dependency: transitive
     description:
@@ -195,10 +195,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: d584fa6707a52763a52446f02cc621b077888fb63b93bbcb1143a7be5a0c0c04
+      sha256: "7687075e408b093f36e6bbf6c91878cc0d4cd10f409506f7bc996f68220b9136"
       url: "https://pub.dev"
     source: hosted
-    version: "1.11.0"
+    version: "1.12.0"
   path:
     dependency: transitive
     description:
@@ -280,10 +280,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "5c2f730018264d276c20e4f1503fd1308dfbbae39ec8ee63c5236311ac06954b"
+      sha256: "9955ae474176f7ac8ee4e989dadfb411a58c30415bcfb648fa04b2b8a03afa7f"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.1"
+    version: "0.7.0"
   typed_data:
     dependency: transitive
     description:
@@ -328,10 +328,10 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: b3d56ff4341b8f182b96aceb2fa20e3dcb336b9f867bc0eafc0de10f1048e957
+      sha256: "3923c89304b715fb1eb6423f017651664a03bf5f4b29983627c4da791f74a4ec"
       url: "https://pub.dev"
     source: hosted
-    version: "13.0.0"
+    version: "14.2.1"
   web:
     dependency: transitive
     description:
@@ -350,4 +350,4 @@ packages:
     version: "6.5.0"
 sdks:
   dart: ">=3.3.0 <4.0.0"
-  flutter: ">=3.7.0-0"
+  flutter: ">=3.18.0-18.0.pre.54"

--- a/lib/src/localization/generated/country_selector_localization_ar.dart
+++ b/lib/src/localization/generated/country_selector_localization_ar.dart
@@ -5,21 +5,21 @@ class CountrySelectorLocalizationAr extends CountrySelectorLocalization {
   CountrySelectorLocalizationAr([super.locale = 'ar']);
 
   @override
-  String get noResultMessage => 'لا نتيجة';
+  String get noResultMessage => 'لا توجد نتائج';
 
   @override
-  String get search => 'يبحث';
+  String get search => 'بحث';
 
   @override
-  String get typeToSearch => 'اكتب هنا للبحث عن دولة';
+  String get typeToSearch => 'اكتب هنا للبحث';
 
   @override
   String selectCountry(String country) {
-    return '$country يختار';
+    return 'اختر $country';
   }
 
   @override
-  String get ac_ => 'جزيرة أسنسيون';
+  String get ac_ => 'جزيرة أسينشين';
 
   @override
   String get ad_ => 'أندورا';
@@ -31,7 +31,7 @@ class CountrySelectorLocalizationAr extends CountrySelectorLocalization {
   String get af_ => 'أفغانستان';
 
   @override
-  String get ag_ => 'أنتيغوا وبربودا';
+  String get ag_ => 'أنتيغوا وباربودا';
 
   @override
   String get ai_ => 'أنغيلا';
@@ -109,7 +109,7 @@ class CountrySelectorLocalizationAr extends CountrySelectorLocalization {
   String get bn_ => 'بروناي دار السلام';
 
   @override
-  String get bo_ => 'بوليفيا ، دولة متعددة القوميات';
+  String get bo_ => 'بوليفيا';
 
   @override
   String get bq_ => 'بونير';
@@ -139,7 +139,7 @@ class CountrySelectorLocalizationAr extends CountrySelectorLocalization {
   String get cc_ => 'جزر كوكوس (كيلينغ)';
 
   @override
-  String get cd_ => 'الكونغو ، جمهورية الكونغو الديمقراطية';
+  String get cd_ => 'الكونغو الديمقراطية';
 
   @override
   String get cf_ => 'جمهورية افريقيا الوسطى';
@@ -151,7 +151,7 @@ class CountrySelectorLocalizationAr extends CountrySelectorLocalization {
   String get ch_ => 'سويسرا';
 
   @override
-  String get ci_ => 'كوت ديفوار';
+  String get ci_ => 'ساحل العاج';
 
   @override
   String get ck_ => 'جزر كوك';
@@ -169,7 +169,7 @@ class CountrySelectorLocalizationAr extends CountrySelectorLocalization {
   String get co_ => 'كولومبيا';
 
   @override
-  String get cr_ => 'كوستا ريكا';
+  String get cr_ => 'كوستاريكا';
 
   @override
   String get cu_ => 'كوبا';
@@ -187,7 +187,7 @@ class CountrySelectorLocalizationAr extends CountrySelectorLocalization {
   String get cy_ => 'قبرص';
 
   @override
-  String get cz_ => 'الجمهورية التشيكية';
+  String get cz_ => 'التشيك';
 
   @override
   String get de_ => 'ألمانيا';
@@ -208,7 +208,7 @@ class CountrySelectorLocalizationAr extends CountrySelectorLocalization {
   String get dz_ => 'الجزائر';
 
   @override
-  String get ec_ => 'الاكوادور';
+  String get ec_ => 'الإكوادور';
 
   @override
   String get ee_ => 'إستونيا';
@@ -226,7 +226,7 @@ class CountrySelectorLocalizationAr extends CountrySelectorLocalization {
   String get es_ => 'إسبانيا';
 
   @override
-  String get et_ => 'أثيوبيا';
+  String get et_ => 'إثيوبيا';
 
   @override
   String get fi_ => 'فنلندا';
@@ -235,19 +235,19 @@ class CountrySelectorLocalizationAr extends CountrySelectorLocalization {
   String get fj_ => 'فيجي';
 
   @override
-  String get fk_ => 'جزر فوكلاند (مالفيناس)';
+  String get fk_ => 'جزر فوكلاند';
 
   @override
   String get fm_ => 'ولايات ميكرونيزيا الموحدة';
 
   @override
-  String get fo_ => 'جزر فاروس';
+  String get fo_ => 'جزر فارو';
 
   @override
   String get fr_ => 'فرنسا';
 
   @override
-  String get ga_ => 'الجابون';
+  String get ga_ => 'الغابون';
 
   @override
   String get gb_ => 'المملكة المتحدة';
@@ -259,7 +259,7 @@ class CountrySelectorLocalizationAr extends CountrySelectorLocalization {
   String get ge_ => 'جورجيا';
 
   @override
-  String get gf_ => 'غيانا الفرنسية';
+  String get gf_ => 'غويانا الفرنسية';
 
   @override
   String get gg_ => 'غيرنسي';
@@ -382,7 +382,7 @@ class CountrySelectorLocalizationAr extends CountrySelectorLocalization {
   String get kp_ => 'كوريا ، جمهورية كوريا الشعبية الديمقراطية';
 
   @override
-  String get kr_ => 'كوريا ، جمهورية كوريا الجنوبية';
+  String get kr_ => 'كوريا الجنوبية';
 
   @override
   String get kw_ => 'الكويت';
@@ -394,19 +394,19 @@ class CountrySelectorLocalizationAr extends CountrySelectorLocalization {
   String get kz_ => 'كازاخستان';
 
   @override
-  String get la_ => 'لاوس';
+  String get la_ => 'جمهورية لاو الديمقراطية الشعبية';
 
   @override
   String get lb_ => 'لبنان';
 
   @override
-  String get lc_ => 'القديسة لوسيا';
+  String get lc_ => 'سانت لوسيا';
 
   @override
   String get li_ => 'ليختنشتاين';
 
   @override
-  String get lk_ => 'سيريلانكا';
+  String get lk_ => 'سريلانكا';
 
   @override
   String get lr_ => 'ليبيريا';
@@ -439,7 +439,7 @@ class CountrySelectorLocalizationAr extends CountrySelectorLocalization {
   String get me_ => 'الجبل الأسود';
 
   @override
-  String get mf_ => 'القديس مارتن';
+  String get mf_ => 'سانت مارتن';
 
   @override
   String get mg_ => 'مدغشقر';
@@ -463,7 +463,7 @@ class CountrySelectorLocalizationAr extends CountrySelectorLocalization {
   String get mo_ => 'ماكاو';
 
   @override
-  String get mp_ => 'جزر مريانا الشمالية';
+  String get mp_ => 'جزر ماريانا الشمالية';
 
   @override
   String get mq_ => 'مارتينيك';
@@ -472,7 +472,7 @@ class CountrySelectorLocalizationAr extends CountrySelectorLocalization {
   String get mr_ => 'موريتانيا';
 
   @override
-  String get ms_ => 'مونتسيرات';
+  String get ms_ => 'مونتسرات';
 
   @override
   String get mt_ => 'مالطا';
@@ -529,7 +529,7 @@ class CountrySelectorLocalizationAr extends CountrySelectorLocalization {
   String get nu_ => 'نيوي';
 
   @override
-  String get nz_ => 'نيوزيلاندا';
+  String get nz_ => 'نيوزيلندا';
 
   @override
   String get om_ => 'سلطنة عمان';
@@ -547,7 +547,7 @@ class CountrySelectorLocalizationAr extends CountrySelectorLocalization {
   String get pg_ => 'بابوا غينيا الجديدة';
 
   @override
-  String get ph_ => 'فيلبيني';
+  String get ph_ => 'الفلبين';
 
   @override
   String get pk_ => 'باكستان';
@@ -577,10 +577,10 @@ class CountrySelectorLocalizationAr extends CountrySelectorLocalization {
   String get py_ => 'باراغواي';
 
   @override
-  String get qa_ => 'دولة قطر';
+  String get qa_ => 'قطر';
 
   @override
-  String get re_ => 'جمع شمل';
+  String get re_ => 'ريونيون';
 
   @override
   String get ro_ => 'رومانيا';
@@ -619,13 +619,13 @@ class CountrySelectorLocalizationAr extends CountrySelectorLocalization {
   String get si_ => 'سلوفينيا';
 
   @override
-  String get sj_ => 'سفالبارد وجان ماين';
+  String get sj_ => 'سفالبارد ويان ماين';
 
   @override
   String get sk_ => 'سلوفاكيا';
 
   @override
-  String get sl_ => 'سيرا ليون';
+  String get sl_ => 'سيراليون';
 
   @override
   String get sm_ => 'سان مارينو';
@@ -652,7 +652,7 @@ class CountrySelectorLocalizationAr extends CountrySelectorLocalization {
   String get sx_ => 'سينت مارتن';
 
   @override
-  String get sy_ => 'الجمهورية العربية السورية';
+  String get sy_ => 'سوريا';
 
   @override
   String get sz_ => 'سوازيلاند';
@@ -661,13 +661,13 @@ class CountrySelectorLocalizationAr extends CountrySelectorLocalization {
   String get ta_ => 'تريستان دا كونها';
 
   @override
-  String get tc_ => 'جزر تركس وكايكوس';
+  String get tc_ => 'جزر توركس وكايكوس';
 
   @override
   String get td_ => 'تشاد';
 
   @override
-  String get tg_ => 'توجو';
+  String get tg_ => 'توغو';
 
   @override
   String get th_ => 'تايلاند';
@@ -676,10 +676,10 @@ class CountrySelectorLocalizationAr extends CountrySelectorLocalization {
   String get tj_ => 'طاجيكستان';
 
   @override
-  String get tk_ => 'توكيلاو';
+  String get tk_ => 'توكيلو';
 
   @override
-  String get tl_ => 'تيمور ليشتي';
+  String get tl_ => 'تيمور- ليشتي';
 
   @override
   String get tm_ => 'تركمانستان';
@@ -691,7 +691,7 @@ class CountrySelectorLocalizationAr extends CountrySelectorLocalization {
   String get to_ => 'تونغا';
 
   @override
-  String get tr_ => 'ديك رومى';
+  String get tr_ => 'تركيا';
 
   @override
   String get tt_ => 'ترينداد وتوباغو';
@@ -721,7 +721,7 @@ class CountrySelectorLocalizationAr extends CountrySelectorLocalization {
   String get uz_ => 'أوزبكستان';
 
   @override
-  String get va_ => 'الكرسي الرسولي (دولة الفاتيكان)';
+  String get va_ => 'دولة الفاتيكان';
 
   @override
   String get vc_ => 'سانت فنسنت وجزر غرينادين';
@@ -730,7 +730,7 @@ class CountrySelectorLocalizationAr extends CountrySelectorLocalization {
   String get ve_ => 'فنزويلا';
 
   @override
-  String get vg_ => 'جزر العذراء البريطانية';
+  String get vg_ => 'جزر فيرجن البريطانية';
 
   @override
   String get vi_ => 'جزر فيرجن الأمريكية';


### PR DESCRIPTION
This PR fixes some literally translated country names in  Arabic e.g Turkey is translated to name of the bird instead of the name of the country.  it also fixes some typos.