### PR TITLE
Fix: Apply sorting only to country list, not favorites

### DIFF
--- a/lib/src/_country_selector_controller.dart
+++ b/lib/src/_country_selector_controller.dart
@@ -20,7 +20,7 @@ class CountrySelectorController with ChangeNotifier {
     List<IsoCode> countriesIsoCode,
     List<IsoCode> favoriteCountriesIsoCode,
   ) {
-    _countries = _buildLocalizedCountryList(context, countriesIsoCode);
+    _countries = _buildLocalizedCountryList(context, countriesIsoCode)..sort((a, b) => a.name.compareTo(b.name));
     _favoriteCountries =
         _buildLocalizedCountryList(context, favoriteCountriesIsoCode);
     _filteredCountries = _countries;
@@ -60,7 +60,6 @@ class CountrySelectorController with ChangeNotifier {
             localization.countryName(isoCode),
           ),
         )
-        .toList()
-      ..sort((a, b) => a.name.compareTo(b.name));
+        .toList();
   }
 }


### PR DESCRIPTION
This PR removes the `sort` function from `_buildLocalizedCountryList` and applies it explicitly only to `_countries` during initialization. This ensures `_favoriteCountries` remain unsorted as per feedback in Issue #25